### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can also directly trigger actions from the CLI like so...
 Options, all commands support the following optional parameters...
 
     --demonstrate       | dont actually run the commands on the server just pretend like you are
-    --sequential        | dont attempt to run commands accross multiple nodes in parrallel
+    --sequential        | dont attempt to run commands across multiple nodes in parrallel
     --throw             | throw a stack trace rather than pretty printing errors
     --file              | path to the orca.rb file to load, defaults to ./orca/orca.rb
     --verbose           | print all SSH output, useful for debugging but can be rather long


### PR DESCRIPTION
@andykent, I've corrected a typographical error in the documentation of the [orca](https://github.com/andykent/orca) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.